### PR TITLE
chore: add endpoint to get suppression resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
 
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
-        <artifactId>companies-house-parent</artifactId>
-        <version>1.2.0</version>
+        <artifactId>companies-house-spring-boot-parent</artifactId>
+        <version>1.4.0</version>
     </parent>
 
     <artifactId>suppression-api</artifactId>

--- a/src/main/java/uk/gov/companieshouse/controller/SuppressionController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/SuppressionController.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.controller;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.commons.lang3.StringUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -11,14 +13,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import uk.gov.companieshouse.model.Suppression;
 import uk.gov.companieshouse.service.SuppressionService;
@@ -27,6 +31,7 @@ import javax.validation.Valid;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/suppressions")
@@ -38,7 +43,7 @@ public class SuppressionController {
 
     public SuppressionController(SuppressionService suppressionService){ this.suppressionService = suppressionService; }
 
-    @Operation(summary = "Create a new suppression", tags = "suppression")
+    @Operation(summary = "Create a new suppression", tags = "Suppression")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "Suppression resource created", headers = {
             @Header(name = "location")
@@ -52,11 +57,11 @@ public class SuppressionController {
     public ResponseEntity<String> submitSuppression(@RequestHeader("ERIC-identity") String userId,
                                                     @Valid @RequestBody final Suppression suppression) {
 
+        LOGGER.info("POST /suppressions with application reference {}", suppression.getApplicationReference());
+        
         if (StringUtils.isBlank(userId)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-
-        LOGGER.info("POST /suppressions with application reference {}", suppression.getApplicationReference());
 
         try {
 
@@ -77,6 +82,29 @@ public class SuppressionController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
 
+    }
+
+    @Operation(summary = "Get suppression by ID", tags = "Suppression")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Suppression resource retrieved successfully",
+            content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Suppression.class))}),
+        @ApiResponse(responseCode = "401", description = "Unauthorised request", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Suppression resource not found", content = @Content)
+    })
+    @GetMapping(value = "/{suppression-id:[A-Z0-9]{5}-[A-Z0-9]{5}}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Suppression> getSuppressionByID(@RequestHeader("ERIC-identity") final String userId,
+                                                          @PathVariable("suppression-id") final String suppressionId) {
+
+        LOGGER.info("GET /suppressions/{}", suppressionId);
+
+        if (StringUtils.isBlank(userId)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        final Optional<Suppression> suppression = suppressionService.getSuppression(suppressionId);
+
+        return suppression.map(s -> ResponseEntity.status(HttpStatus.OK).body(s))
+            .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
     }
 
     @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)

--- a/src/main/java/uk/gov/companieshouse/controller/SuppressionController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/SuppressionController.java
@@ -41,7 +41,9 @@ public class SuppressionController {
 
     private final SuppressionService suppressionService;
 
-    public SuppressionController(SuppressionService suppressionService){ this.suppressionService = suppressionService; }
+    public SuppressionController(SuppressionService suppressionService) {
+        this.suppressionService = suppressionService;
+    }
 
     @Operation(summary = "Create a new suppression", tags = "Suppression")
     @ApiResponses(value = {
@@ -91,8 +93,8 @@ public class SuppressionController {
         @ApiResponse(responseCode = "401", description = "Unauthorised request", content = @Content),
         @ApiResponse(responseCode = "404", description = "Suppression resource not found", content = @Content)
     })
-    @GetMapping(value = "/{suppression-id:[A-Z0-9]{5}-[A-Z0-9]{5}}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Suppression> getSuppressionByID(@RequestHeader("ERIC-identity") final String userId,
+    @GetMapping(value = "/{suppression-id:^[A-Z0-9]{5}-[A-Z0-9]{5}}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Suppression> getSuppressionById(@RequestHeader("ERIC-identity") final String userId,
                                                           @PathVariable("suppression-id") final String suppressionId) {
 
         LOGGER.info("GET /suppressions/{}", suppressionId);

--- a/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest_GET.java
+++ b/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest_GET.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PaymentController.class)
-public class PaymentControllerTest_POST {
+public class PaymentControllerTest_GET {
 
     private final String SUPPRESSIONS_PAYMENT_URI = "/suppressions/{suppression-id}/payment";
     private final String TEST_SUPPRESSION_ID = "123";

--- a/src/test/java/uk/gov/companieshouse/controller/SuppressionControllerTest_GET.java
+++ b/src/test/java/uk/gov/companieshouse/controller/SuppressionControllerTest_GET.java
@@ -42,9 +42,9 @@ public class SuppressionControllerTest_GET {
     @Test
     public void whenSuppressionResourceExistsForSuppressionID_return200() throws Exception {
 
-        Suppression suppressionResource = getSuppressionResource();
+        final Suppression suppressionResource = getSuppressionResource();
 
-        given(suppressionService.getSuppression(anyString())).willReturn(Optional.of(getSuppressionResource()));
+        given(suppressionService.getSuppression(anyString())).willReturn(Optional.of(suppressionResource));
 
         mockMvc.perform(get(SUPPRESSION_URI, TEST_SUPPRESSION_ID)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -56,8 +56,6 @@ public class SuppressionControllerTest_GET {
     @Test
     public void whenMissingEricIdentityHeader_return400() throws Exception {
 
-        given(suppressionService.getSuppression(anyString())).willReturn(Optional.empty());
-
         mockMvc.perform(get(SUPPRESSION_URI, TEST_SUPPRESSION_ID)
             .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isBadRequest());
@@ -65,8 +63,6 @@ public class SuppressionControllerTest_GET {
 
     @Test
     public void whenBlankEricIdentityHeader_return401() throws Exception {
-
-        given(suppressionService.getSuppression(anyString())).willReturn(Optional.empty());
 
         mockMvc.perform(get(SUPPRESSION_URI, TEST_SUPPRESSION_ID)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -77,8 +73,6 @@ public class SuppressionControllerTest_GET {
     @Test
     public void whenBlankSuppressionId_return404() throws Exception {
 
-        given(suppressionService.getSuppression(anyString())).willReturn(Optional.empty());
-
         mockMvc.perform(get(SUPPRESSION_URI, " ")
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .headers(createHttpHeaders()))
@@ -87,8 +81,6 @@ public class SuppressionControllerTest_GET {
 
     @Test
     public void whenInvalidSuppressionIdFormat_return404() throws Exception {
-
-        given(suppressionService.getSuppression(anyString())).willReturn(Optional.empty());
 
         mockMvc.perform(get(SUPPRESSION_URI, TEST_SUPPRESSION_ID + "-" + TEST_SUPPRESSION_ID)
             .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/uk/gov/companieshouse/controller/SuppressionControllerTest_GET.java
+++ b/src/test/java/uk/gov/companieshouse/controller/SuppressionControllerTest_GET.java
@@ -90,7 +90,7 @@ public class SuppressionControllerTest_GET {
 
         given(suppressionService.getSuppression(anyString())).willReturn(Optional.empty());
 
-        mockMvc.perform(get(SUPPRESSION_URI, "123")
+        mockMvc.perform(get(SUPPRESSION_URI, TEST_SUPPRESSION_ID + "-" + TEST_SUPPRESSION_ID)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .headers(createHttpHeaders()))
             .andExpect(status().isNotFound());

--- a/src/test/java/uk/gov/companieshouse/controller/SuppressionControllerTest_GET.java
+++ b/src/test/java/uk/gov/companieshouse/controller/SuppressionControllerTest_GET.java
@@ -1,0 +1,135 @@
+package uk.gov.companieshouse.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.companieshouse.model.Address;
+import uk.gov.companieshouse.model.ApplicantDetails;
+import uk.gov.companieshouse.model.DocumentDetails;
+import uk.gov.companieshouse.model.Suppression;
+import uk.gov.companieshouse.service.SuppressionService;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SuppressionController.class)
+public class SuppressionControllerTest_GET {
+
+    private static final String SUPPRESSION_URI = "/suppressions/{suppression-id}";
+    private static final String TEST_SUPPRESSION_ID = "11111-11111";
+    private static final String IDENTITY_HEADER = "ERIC-identity";
+    private static final String TEST_USER_ID = "1234";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SuppressionService suppressionService;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void whenSuppressionResourceExistsForSuppressionID_return200() throws Exception {
+
+        Suppression suppressionResource = getSuppressionResource();
+
+        given(suppressionService.getSuppression(anyString())).willReturn(Optional.of(getSuppressionResource()));
+
+        mockMvc.perform(get(SUPPRESSION_URI, TEST_SUPPRESSION_ID)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .headers(createHttpHeaders()))
+            .andExpect(status().isOk())
+            .andExpect(content().json(asJsonString(suppressionResource)));
+    }
+
+    @Test
+    public void whenMissingEricIdentityHeader_return400() throws Exception {
+
+        given(suppressionService.getSuppression(anyString())).willReturn(Optional.empty());
+
+        mockMvc.perform(get(SUPPRESSION_URI, TEST_SUPPRESSION_ID)
+            .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void whenBlankEricIdentityHeader_return401() throws Exception {
+
+        given(suppressionService.getSuppression(anyString())).willReturn(Optional.empty());
+
+        mockMvc.perform(get(SUPPRESSION_URI, TEST_SUPPRESSION_ID)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header(IDENTITY_HEADER, ""))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void whenBlankSuppressionId_return404() throws Exception {
+
+        given(suppressionService.getSuppression(anyString())).willReturn(Optional.empty());
+
+        mockMvc.perform(get(SUPPRESSION_URI, " ")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .headers(createHttpHeaders()))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void whenInvalidSuppressionIdFormat_return404() throws Exception {
+
+        given(suppressionService.getSuppression(anyString())).willReturn(Optional.empty());
+
+        mockMvc.perform(get(SUPPRESSION_URI, "123")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .headers(createHttpHeaders()))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void whenSuppressionResourceNotFound_return404() throws Exception {
+
+        given(suppressionService.getSuppression(anyString())).willReturn(Optional.empty());
+
+        mockMvc.perform(get(SUPPRESSION_URI, TEST_SUPPRESSION_ID)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .headers(createHttpHeaders()))
+            .andExpect(status().isNotFound());
+    }
+
+    private <T> String asJsonString(T body) {
+        try {
+            return mapper.writeValueAsString(body);
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Suppression getSuppressionResource() {
+        Suppression suppression = new Suppression();
+        suppression.setApplicationReference(TEST_SUPPRESSION_ID);
+        suppression.setCreatedAt(LocalDateTime.now());
+        suppression.setAddressToRemove(new Address());
+        suppression.setApplicantDetails(new ApplicantDetails());
+        suppression.setDocumentDetails(new DocumentDetails());
+        suppression.setServiceAddress(new Address());
+        suppression.setEtag("I_AM_AN_ETAG");
+        return suppression;
+    }
+
+    private HttpHeaders createHttpHeaders() {
+        final HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(IDENTITY_HEADER, TEST_USER_ID);
+        return httpHeaders;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/service/SuppressionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/SuppressionServiceTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.times;
 @ExtendWith(MockitoExtension.class)
 public class SuppressionServiceTest {
 
+    private static final String TEST_SUPPRESSION_ID = "reference#01";
+
     @InjectMocks
     private SuppressionService suppressionService;
 
@@ -42,32 +44,50 @@ public class SuppressionServiceTest {
     @Test
     public void isExistingSuppressionID_returnsFalse() {
 
-        String existingID = "reference#01";
-        when(suppressionRepository.findById(existingID)).thenReturn(Optional.empty());
-        assertFalse(suppressionService.isExistingSuppressionID(existingID));
+        when(suppressionRepository.findById(TEST_SUPPRESSION_ID)).thenReturn(Optional.empty());
+        assertFalse(suppressionService.isExistingSuppressionID(TEST_SUPPRESSION_ID));
     }
 
     @Test
     public void isExistingSuppressionID_returnsTrue() {
 
-        String nonExistingID = "reference#01";
-        when(suppressionRepository.findById(nonExistingID)).thenReturn(Optional.of(createSuppressionEntity(nonExistingID)));
-        assertTrue(suppressionService.isExistingSuppressionID(nonExistingID));
+        when(suppressionRepository.findById(TEST_SUPPRESSION_ID)).thenReturn(Optional.of(createSuppressionEntity(TEST_SUPPRESSION_ID)));
+        assertTrue(suppressionService.isExistingSuppressionID(TEST_SUPPRESSION_ID));
     }
+
+    @Test
+    public void testGetExistingSuppression_returnsResource() {
+
+        final Suppression suppression = createSuppression(TEST_SUPPRESSION_ID);
+
+        when(suppressionMapper.map(any(SuppressionEntity.class))).thenReturn(suppression);
+        when(suppressionRepository.findById(TEST_SUPPRESSION_ID)).thenReturn(Optional.of(createSuppressionEntity(TEST_SUPPRESSION_ID)));
+
+        assertEquals(Optional.of(suppression), suppressionService.getSuppression(TEST_SUPPRESSION_ID));
+    }
+
+    @Test
+    public void testGetNonExistingSuppression_returnsEmptyResource() {
+
+        when(suppressionRepository.findById(TEST_SUPPRESSION_ID)).thenReturn(Optional.empty());
+
+        assertEquals(Optional.empty(), suppressionService.getSuppression(TEST_SUPPRESSION_ID));
+    }
+
 
     @Test
     public void testSaveSuppression_returnsResourceReference() {
 
-        when(suppressionMapper.map(any(Suppression.class))).thenReturn(createSuppressionEntity("reference#01"));
+        when(suppressionMapper.map(any(Suppression.class))).thenReturn(createSuppressionEntity(TEST_SUPPRESSION_ID));
         when(suppressionRepository.save(any(SuppressionEntity.class))).thenReturn(createSuppressionEntity(TestData.Suppression.applicationReference));
 
-        assertEquals(TestData.Suppression.applicationReference, suppressionService.saveSuppression(createSuppression("reference#01")));
+        assertEquals(TestData.Suppression.applicationReference, suppressionService.saveSuppression(createSuppression(TEST_SUPPRESSION_ID)));
     }
 
     @Test
     public void testSaveSuppressionWithEmptyReference_returnsResourceReference() {
 
-        when(suppressionMapper.map(any(Suppression.class))).thenReturn(createSuppressionEntity("reference#01"));
+        when(suppressionMapper.map(any(Suppression.class))).thenReturn(createSuppressionEntity(TEST_SUPPRESSION_ID));
         when(suppressionRepository.save(any(SuppressionEntity.class))).thenReturn(createSuppressionEntity(TestData.Suppression.applicationReference));
 
         String expectedReference = suppressionService.saveSuppression(createSuppression(""));


### PR DESCRIPTION
### JIRA
https://companieshouse.atlassian.net/browse/SR-90

### Change description
Created new endpoint for retrieving suppression resource from mongodb by ID.

### Swagger Screenshot
<img width="1742" alt="Screenshot 2020-09-18 at 13 42 40" src="https://user-images.githubusercontent.com/16392604/93598690-f77fd180-f9b4-11ea-9042-59e7404773ce.png">


### Work Checklist

- [x] Tests added where applicable
- [ ] Test coverage of new code meets target of 80%

---

### Merge Instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
