### PR TITLE
feat: Use ERIC identity instead of applicantDetails.emailAddress

### DIFF
--- a/src/main/java/uk/gov/companieshouse/controller/SuppressionController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/SuppressionController.java
@@ -59,6 +59,7 @@ public class SuppressionController {
     })
     @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> submitSuppression(@RequestHeader("ERIC-identity") String userId,
+                                                    @RequestHeader("ERIC-Authorised-User") String authorisedUser,
                                                     @Valid @RequestBody final ApplicantDetails applicantDetails) {
 
         if (StringUtils.isBlank(userId)) {
@@ -66,9 +67,8 @@ public class SuppressionController {
         }
 
         try {
-
-            final String id = suppressionService.saveSuppression(applicantDetails);
-
+            final String createdBy = authorisedUser.split(";")[0];
+            final String id = suppressionService.saveSuppression(applicantDetails, createdBy);
             final URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
                 .path("/{applicationReference}")

--- a/src/main/java/uk/gov/companieshouse/controller/SuppressionController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/SuppressionController.java
@@ -67,7 +67,7 @@ public class SuppressionController {
         }
 
         try {
-            final String createdBy = authorisedUser.split(";")[0];
+            final String createdBy = authorisedUser.split(" ")[0];
             final String id = suppressionService.saveSuppression(applicantDetails, createdBy);
             final URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()

--- a/src/main/java/uk/gov/companieshouse/controller/SuppressionController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/SuppressionController.java
@@ -62,7 +62,7 @@ public class SuppressionController {
                                                     @RequestHeader("ERIC-Authorised-User") String authorisedUser,
                                                     @Valid @RequestBody final ApplicantDetails applicantDetails) {
 
-        if (StringUtils.isBlank(userId)) {
+        if (StringUtils.isBlank(userId) || StringUtils.isBlank(authorisedUser)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 

--- a/src/main/java/uk/gov/companieshouse/database/entity/ApplicantDetailsEntity.java
+++ b/src/main/java/uk/gov/companieshouse/database/entity/ApplicantDetailsEntity.java
@@ -12,21 +12,17 @@ public class ApplicantDetailsEntity implements Serializable {
 
     private final String fullName;
     private final String previousName;
-    private final String emailAddress;
     private final String dateOfBirth;
 
-    public ApplicantDetailsEntity(String fullName, String previousName, String emailAddress, String dateOfBirth){
+    public ApplicantDetailsEntity(String fullName, String previousName, String dateOfBirth){
         this.fullName = fullName;
         this.previousName = previousName;
-        this.emailAddress = emailAddress;
         this.dateOfBirth = dateOfBirth;
     }
 
     public String getFullName() { return this.fullName; }
 
     public String getPreviousName() { return this.previousName; }
-
-    public String getEmailAddress() { return this.emailAddress; }
 
     public String getDateOfBirth() { return this.dateOfBirth; }
 
@@ -41,7 +37,6 @@ public class ApplicantDetailsEntity implements Serializable {
         return new EqualsBuilder()
             .append(fullName, that.fullName)
             .append(previousName, that.previousName)
-            .append(emailAddress, that.emailAddress)
             .append(dateOfBirth, that.dateOfBirth)
             .isEquals();
     }
@@ -51,7 +46,6 @@ public class ApplicantDetailsEntity implements Serializable {
         return new HashCodeBuilder()
             .append(fullName)
             .append(previousName)
-            .append(emailAddress)
             .append(dateOfBirth)
             .toHashCode();
     }
@@ -61,7 +55,6 @@ public class ApplicantDetailsEntity implements Serializable {
         return new ToStringBuilder(this)
             .append("fullName", fullName)
             .append("previousName", previousName)
-            .append("emailAddress", emailAddress)
             .append("dateOfBirth", dateOfBirth)
             .toString();
     }

--- a/src/main/java/uk/gov/companieshouse/database/entity/SuppressionEntity.java
+++ b/src/main/java/uk/gov/companieshouse/database/entity/SuppressionEntity.java
@@ -18,6 +18,7 @@ public class SuppressionEntity implements Serializable {
     @SuppressWarnings("FieldMayBeFinal") // Non final field is required by Spring Data
     private final String id;
     private final LocalDateTime createdAt;
+    private final String createdBy;
     private final ApplicantDetailsEntity applicantDetails;
     private final AddressEntity addressToRemove;
     private final AddressEntity serviceAddress;
@@ -28,6 +29,7 @@ public class SuppressionEntity implements Serializable {
 
     public SuppressionEntity(String id,
                              LocalDateTime createdAt,
+                             String createdBy,
                              ApplicantDetailsEntity applicantDetails,
                              AddressEntity addressToRemove,
                              AddressEntity serviceAddress,
@@ -37,6 +39,7 @@ public class SuppressionEntity implements Serializable {
                              PaymentDetailsEntity paymentDetails) {
         this.id = id;
         this.createdAt = createdAt;
+        this.createdBy = createdBy;
         this.applicantDetails = applicantDetails;
         this.addressToRemove = addressToRemove;
         this.serviceAddress = serviceAddress;
@@ -49,6 +52,8 @@ public class SuppressionEntity implements Serializable {
     public String getId() { return this.id; }
 
     public LocalDateTime getCreatedAt() { return this.createdAt; }
+
+    public String getCreatedBy() { return this.createdBy; }
 
     public ApplicantDetailsEntity getApplicantDetails() { return this.applicantDetails; }
 
@@ -81,6 +86,7 @@ public class SuppressionEntity implements Serializable {
         return new EqualsBuilder()
             .append(id, that.id)
             .append(createdAt, that.createdAt)
+            .append(createdBy, that.createdBy)
             .append(applicantDetails, that.applicantDetails)
             .append(addressToRemove, that.addressToRemove)
             .append(serviceAddress, that.serviceAddress)
@@ -96,6 +102,7 @@ public class SuppressionEntity implements Serializable {
         return new HashCodeBuilder()
             .append(id)
             .append(createdAt)
+            .append(createdBy)
             .append(applicantDetails)
             .append(addressToRemove)
             .append(serviceAddress)
@@ -111,6 +118,7 @@ public class SuppressionEntity implements Serializable {
         return new ToStringBuilder(this)
             .append("id", id)
             .append("createdAt", createdAt)
+            .append("createdAt", createdBy)
             .append("applicantDetails", applicantDetails)
             .append("addressToRemove", addressToRemove)
             .append("serviceAddress", serviceAddress)

--- a/src/main/java/uk/gov/companieshouse/mapper/ApplicantDetailsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/ApplicantDetailsMapper.java
@@ -16,7 +16,6 @@ public class ApplicantDetailsMapper implements Mapper<ApplicantDetailsEntity, Ap
         return new ApplicantDetailsEntity(
             value.getFullName(),
             value.getPreviousName(),
-            value.getEmailAddress(),
             value.getDateOfBirth()
         );
     }
@@ -29,7 +28,6 @@ public class ApplicantDetailsMapper implements Mapper<ApplicantDetailsEntity, Ap
         return new ApplicantDetails(
             value.getFullName(),
             value.getPreviousName(),
-            value.getEmailAddress(),
             value.getDateOfBirth()
         );
     }

--- a/src/main/java/uk/gov/companieshouse/mapper/SuppressionMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/SuppressionMapper.java
@@ -32,6 +32,7 @@ public class SuppressionMapper implements Mapper<SuppressionEntity, Suppression>
         return new SuppressionEntity(
             value.getApplicationReference(),
             value.getCreatedAt(),
+            value.getCreatedBy(),
             applicantDetailsMapper.map(value.getApplicantDetails()),
             addressMapper.map(value.getAddressToRemove()),
             addressMapper.map(value.getServiceAddress()),
@@ -49,6 +50,7 @@ public class SuppressionMapper implements Mapper<SuppressionEntity, Suppression>
         }
         return new Suppression(
             value.getCreatedAt(),
+            value.getCreatedBy(),
             value.getId(),
             applicantDetailsMapper.map(value.getApplicantDetails()),
             addressMapper.map(value.getAddressToRemove()),

--- a/src/main/java/uk/gov/companieshouse/model/ApplicantDetails.java
+++ b/src/main/java/uk/gov/companieshouse/model/ApplicantDetails.java
@@ -13,19 +13,15 @@ public class ApplicantDetails {
 
     private String previousName;
 
-    @NotBlank(message = "email address must not be blank")
-    private String emailAddress;
-
     @NotBlank(message = "date of birth must not be blank")
     private String dateOfBirth;
 
     public ApplicantDetails() {
-        this(null, null, null, null);
+        this(null, null, null);
     }
 
-    public ApplicantDetails(String fullName, String previousName, String emailAddress, String dateOfBirth){
+    public ApplicantDetails(String fullName, String previousName, String dateOfBirth){
         this.fullName = fullName;
-        this.emailAddress = emailAddress;
         this.previousName = previousName;
         this.dateOfBirth = dateOfBirth;
     }
@@ -34,18 +30,13 @@ public class ApplicantDetails {
 
     public String getPreviousName() { return this.previousName; }
 
-    public String getEmailAddress() { return this.emailAddress; }
-
     public String getDateOfBirth() { return this.dateOfBirth; }
 
     public void setFullName(String fullName) { this.fullName = fullName; }
 
     public void setPreviousName(String previousName) { this.previousName = previousName; }
 
-    public void setEmailAddress(String emailAddress) { this.emailAddress = emailAddress; }
-
     public void setDateOfBirth(String dateOfBirth) { this.dateOfBirth = dateOfBirth; }
-
 
     @Override
     public boolean equals(Object o) {
@@ -58,7 +49,6 @@ public class ApplicantDetails {
         return new EqualsBuilder()
             .append(fullName, that.fullName)
             .append(previousName, that.previousName)
-            .append(emailAddress, that.emailAddress)
             .append(dateOfBirth, that.dateOfBirth)
             .isEquals();
     }
@@ -68,7 +58,6 @@ public class ApplicantDetails {
         return new HashCodeBuilder()
             .append(fullName)
             .append(previousName)
-            .append(emailAddress)
             .append(dateOfBirth)
             .toHashCode();
     }
@@ -78,7 +67,6 @@ public class ApplicantDetails {
         return new ToStringBuilder(this)
             .append("fullName", fullName)
             .append("previousName", previousName)
-            .append("emailAddress", emailAddress)
             .append("dateOfBirth", dateOfBirth)
             .toString();
     }

--- a/src/main/java/uk/gov/companieshouse/model/Suppression.java
+++ b/src/main/java/uk/gov/companieshouse/model/Suppression.java
@@ -13,6 +13,8 @@ public class Suppression {
     @JsonIgnore
     private LocalDateTime createdAt;
 
+    private String createdBy;
+
     @Pattern(regexp = "([A-Z0-9]{5}-[A-Z0-9]{5})|^$", message = "applicationReference format is invalid")
     private String applicationReference;
 
@@ -25,10 +27,11 @@ public class Suppression {
     private PaymentDetails paymentDetails;
 
     public Suppression() {
-        this(null, null, null, null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null, null, null, null);
     }
 
     public Suppression(LocalDateTime createdAt,
+                       String createdBy,
                        String applicationReference,
                        ApplicantDetails applicantDetails,
                        Address addressToRemove,
@@ -38,6 +41,7 @@ public class Suppression {
                        String etag,
                        PaymentDetails paymentDetails) {
         this.createdAt = createdAt;
+        this.createdBy = createdBy;
         this.applicationReference = applicationReference;
         this.applicantDetails = applicantDetails;
         this.addressToRemove = addressToRemove;
@@ -52,65 +56,41 @@ public class Suppression {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
-        this.createdAt = createdAt;
-    }
+    public String getCreatedBy() { return createdBy; }
 
-    public String getApplicationReference() {
-        return applicationReference;
-    }
+    public String getApplicationReference() { return applicationReference; }
 
-    public void setApplicationReference(String applicationReference) {
-        this.applicationReference = applicationReference;
-    }
+    public ApplicantDetails getApplicantDetails() { return applicantDetails; }
 
-    public ApplicantDetails getApplicantDetails() {
-        return applicantDetails;
-    }
+    public Address getAddressToRemove() { return addressToRemove; }
 
-    public void setApplicantDetails(ApplicantDetails applicantDetails) {
-        this.applicantDetails = applicantDetails;
-    }
+    public Address getServiceAddress() { return serviceAddress; }
 
-    public Address getAddressToRemove() {
-        return addressToRemove;
-    }
-
-    public void setAddressToRemove(Address addressToRemove) {
-        this.addressToRemove = addressToRemove;
-    }
-
-    public Address getServiceAddress() {
-        return serviceAddress;
-    }
-
-    public void setServiceAddress(Address serviceAddress) {
-        this.serviceAddress = serviceAddress;
-    }
-
-    public DocumentDetails getDocumentDetails() {
-        return documentDetails;
-    }
-
-    public void setDocumentDetails(DocumentDetails documentDetails) {
-        this.documentDetails = documentDetails;
-    }
+    public DocumentDetails getDocumentDetails() { return documentDetails; }
 
     public Address getContactAddress() { return contactAddress; }
 
+    public String getEtag() { return etag; }
+
+    public PaymentDetails getPaymentDetails() { return paymentDetails; }
+
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public void setCreatedBy(String createdBy) { this.createdBy = createdBy; }
+
+    public void setApplicationReference(String applicationReference) { this.applicationReference = applicationReference; }
+
+    public void setApplicantDetails(ApplicantDetails applicantDetails) { this.applicantDetails = applicantDetails; }
+
+    public void setAddressToRemove(Address addressToRemove) { this.addressToRemove = addressToRemove; }
+
+    public void setServiceAddress(Address serviceAddress) { this.serviceAddress = serviceAddress; }
+
+    public void setDocumentDetails(DocumentDetails documentDetails) { this.documentDetails = documentDetails; }
+
     public void setContactAddress(Address contactAddress) { this.contactAddress = contactAddress; }
 
-    public String getEtag() {
-        return etag;
-    }
-
-    public void setEtag(String etag) {
-        this.etag = etag;
-    }
-
-    public PaymentDetails getPaymentDetails() {
-        return paymentDetails;
-    }
+    public void setEtag(String etag) { this.etag = etag; }
 
     public void setPaymentDetails(PaymentDetails paymentDetails) {
         this.paymentDetails = paymentDetails;
@@ -126,6 +106,7 @@ public class Suppression {
 
         return new EqualsBuilder()
             .append(createdAt, that.createdAt)
+            .append(createdBy, that.createdBy)
             .append(applicationReference, that.applicationReference)
             .append(applicantDetails, that.applicantDetails)
             .append(addressToRemove, that.addressToRemove)
@@ -141,6 +122,7 @@ public class Suppression {
     public int hashCode() {
         return new HashCodeBuilder()
             .append(createdAt)
+            .append(createdBy)
             .append(applicationReference)
             .append(applicantDetails)
             .append(addressToRemove)
@@ -156,6 +138,7 @@ public class Suppression {
     public String toString() {
         return new ToStringBuilder(this)
             .append("createdAt", createdAt)
+            .append("createdBy", createdBy)
             .append("applicationReference", applicationReference)
             .append("applicantDetails", applicantDetails)
             .append("addressToRemove", addressToRemove)

--- a/src/main/java/uk/gov/companieshouse/model/Suppression.java
+++ b/src/main/java/uk/gov/companieshouse/model/Suppression.java
@@ -13,6 +13,7 @@ public class Suppression {
     @JsonIgnore
     private LocalDateTime createdAt;
 
+    @JsonIgnore
     private String createdBy;
 
     @Pattern(regexp = "([A-Z0-9]{5}-[A-Z0-9]{5})|^$", message = "applicationReference format is invalid")

--- a/src/main/java/uk/gov/companieshouse/model/email/ApplicationReceivedEmailData.java
+++ b/src/main/java/uk/gov/companieshouse/model/email/ApplicationReceivedEmailData.java
@@ -12,16 +12,18 @@ public class ApplicationReceivedEmailData extends EmailData {
     private Suppression suppression;
     private String applicantDateOfBirth;
     private String documentDate;
+    private String contactEmailAddress;
 
     public ApplicationReceivedEmailData() {
-        this(null, null, null);
+        this(null, null, null, null);
     }
 
-    public ApplicationReceivedEmailData(Suppression suppression, String applicantDateOfBirth, String documentDate) {
+    public ApplicationReceivedEmailData(Suppression suppression, String applicantDateOfBirth, String documentDate, String contactEmailAddress) {
     
         this.suppression = suppression;
         this.applicantDateOfBirth = applicantDateOfBirth;
         this.documentDate = documentDate;
+        this.contactEmailAddress = contactEmailAddress;
     }
 
     public Suppression getSuppression() { return suppression; }
@@ -30,11 +32,15 @@ public class ApplicationReceivedEmailData extends EmailData {
 
     public String getDocumentDate() { return documentDate; }
 
+    public String getContactEmailAddress() { return contactEmailAddress; }
+
     public void setSuppression(Suppression suppression) { this.suppression = suppression; }
 
     public void setApplicantDateOfBirth(String applicantDateOfBirth) { this.applicantDateOfBirth = applicantDateOfBirth; }
 
     public void setDocumentDate(String documentDate) { this.documentDate = documentDate; }
+
+    public void setContactEmailAddress(String contactEmailAddress) { this.contactEmailAddress = contactEmailAddress; }
 
     @Override
     public boolean equals(Object o) {
@@ -50,6 +56,7 @@ public class ApplicationReceivedEmailData extends EmailData {
             .append(suppression, that.suppression)
             .append(applicantDateOfBirth, that.applicantDateOfBirth)
             .append(documentDate, that.documentDate)
+            .append(contactEmailAddress, that.contactEmailAddress)
             .isEquals();
     }
 
@@ -61,6 +68,7 @@ public class ApplicationReceivedEmailData extends EmailData {
             .append(suppression)
             .append(applicantDateOfBirth)
             .append(documentDate)
+            .append(contactEmailAddress)
             .toHashCode();
     }
 
@@ -72,6 +80,7 @@ public class ApplicationReceivedEmailData extends EmailData {
             .append("suppression", suppression)
             .append("applicantDateOfBirth", applicantDateOfBirth)
             .append("documentDate", documentDate)
+            .append("contactEmailAddress", contactEmailAddress)
             .toString();
     }
 

--- a/src/main/java/uk/gov/companieshouse/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/service/EmailService.java
@@ -60,7 +60,7 @@ public class EmailService {
         String documentDate = convertDateToHumanReadableFormat(documentDetails.getDate());
 
         final ApplicationConfirmationEmailData emailData = new ApplicationConfirmationEmailData();
-        emailData.setTo(suppression.getApplicantDetails().getEmailAddress());
+        emailData.setTo(suppression.getCreatedBy());
         emailData.setSubject(subject);
         emailData.setSuppressionReference(applicationReference);
         emailData.setDocumentDetails(documentDetails);

--- a/src/main/java/uk/gov/companieshouse/service/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/service/EmailService.java
@@ -48,6 +48,7 @@ public class EmailService {
         emailData.setSuppression(suppression);
         emailData.setApplicantDateOfBirth(applicantDateOfBirth);
         emailData.setDocumentDate(documentDate);
+        emailData.setContactEmailAddress(suppression.getCreatedBy());
 
         logger.debug(String.format("Sending Submission email for #%s to staff", emailData.getSuppression().getApplicationReference()));
         this.sendEmail(emailData, APPLICATION_RECEIVED_MESSAGE_TYPE);

--- a/src/main/java/uk/gov/companieshouse/service/SuppressionService.java
+++ b/src/main/java/uk/gov/companieshouse/service/SuppressionService.java
@@ -33,13 +33,14 @@ public class SuppressionService {
         this.logger = logger;
     }
 
-    public String saveSuppression(ApplicantDetails applicantDetails) {
+    public String saveSuppression(ApplicantDetails applicantDetails, String createdBy) {
 
         final Suppression suppression = new Suppression();
         suppression.setApplicantDetails(applicantDetails);
         suppression.setApplicationReference(generateUniqueSuppressionReference());
         suppression.setEtag(GenerateEtagUtil.generateEtag());
         suppression.setCreatedAt(LocalDateTime.now());
+        suppression.setCreatedBy(createdBy);
 
         return suppressionRepository.save(this.suppressionMapper.map(suppression)).getId();
     }

--- a/src/test/java/uk/gov/companieshouse/TestData.java
+++ b/src/test/java/uk/gov/companieshouse/TestData.java
@@ -10,12 +10,12 @@ import java.util.Map;
 public interface TestData {
     interface Suppression {
         LocalDateTime createdAt = LocalDateTime.of(2010, 12, 31, 23, 59);
+        String createdBy = "user@example.com";
         String applicationReference = "11111-11111";
 
         interface ApplicantDetails {
             String fullName = "USER#1";
             String previousName = "USER#2";
-            String emailAddress = "user@example.com";
             String dateOfBirth = "1980-05-01";
         }
 

--- a/src/test/java/uk/gov/companieshouse/controller/SuppressionControllerTest_PATCH.java
+++ b/src/test/java/uk/gov/companieshouse/controller/SuppressionControllerTest_PATCH.java
@@ -197,9 +197,9 @@ class SuppressionControllerTest_PATCH {
         doNothing().when(suppressionService).patchSuppressionResource(any(Suppression.class), any(SuppressionPatchRequest.class));
 
         final Suppression updateSuppressionRequest = new Suppression();
-        updateSuppressionRequest.setApplicantDetails(new ApplicantDetails(TestData.Suppression.ApplicantDetails.fullName,
+        updateSuppressionRequest.setApplicantDetails(new ApplicantDetails(
+            TestData.Suppression.ApplicantDetails.fullName,
             TestData.Suppression.ApplicantDetails.previousName,
-            null,
             " "));
 
         mockMvc.perform(patch(SUPPRESSION_URI, applicationReference)

--- a/src/test/java/uk/gov/companieshouse/controller/SuppressionControllerTest_POST.java
+++ b/src/test/java/uk/gov/companieshouse/controller/SuppressionControllerTest_POST.java
@@ -21,12 +21,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static uk.gov.companieshouse.JsonConverter.convertObjectToJsonString;
 import static uk.gov.companieshouse.TestData.Suppression.applicationReference;
+import static uk.gov.companieshouse.TestData.Suppression.createdBy;
 
 @WebMvcTest(SuppressionController.class)
 class SuppressionControllerTest_POST {
 
     private static final String SUPPRESSION_URI = "/suppressions";
     private static final String IDENTITY_HEADER = "ERIC-identity";
+    private static final String AUTHORISED_USER_HEADER = "ERIC-Authorised-User";
     private static final String TEST_USER_ID = "1234";
 
     @MockBean
@@ -40,7 +42,8 @@ class SuppressionControllerTest_POST {
 
     @BeforeEach
     void setUp() {
-        when(suppressionService.saveSuppression(any(ApplicantDetails.class))).thenReturn(applicationReference);
+        when(suppressionService.saveSuppression(any(ApplicantDetails.class), any(String.class)))
+            .thenReturn(applicationReference);
     }
 
     @Test
@@ -94,7 +97,8 @@ class SuppressionControllerTest_POST {
     @Test
     void whenExceptionFromService_return500() throws Exception {
 
-        when(suppressionService.saveSuppression(any(ApplicantDetails.class))).thenThrow(new RuntimeException());
+        when(suppressionService.saveSuppression(any(ApplicantDetails.class), any(String.class)))
+            .thenThrow(new RuntimeException());
 
         mockMvc.perform(post(SUPPRESSION_URI)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -106,6 +110,7 @@ class SuppressionControllerTest_POST {
     private HttpHeaders createHttpHeaders(String testUserId) {
         final HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(IDENTITY_HEADER, testUserId);
+        httpHeaders.add(AUTHORISED_USER_HEADER, createdBy);
         return httpHeaders;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/fixtures/SuppressionEntityFixtures.java
+++ b/src/test/java/uk/gov/companieshouse/fixtures/SuppressionEntityFixtures.java
@@ -13,10 +13,10 @@ public class SuppressionEntityFixtures {
         return new SuppressionEntity(
             id,
             TestData.Suppression.createdAt,
+            TestData.Suppression.createdBy,
             new ApplicantDetailsEntity(
                 TestData.Suppression.ApplicantDetails.fullName,
                 TestData.Suppression.ApplicantDetails.previousName,
-                TestData.Suppression.ApplicantDetails.emailAddress,
                 TestData.Suppression.ApplicantDetails.dateOfBirth
             ),
             new AddressEntity(

--- a/src/test/java/uk/gov/companieshouse/fixtures/SuppressionFixtures.java
+++ b/src/test/java/uk/gov/companieshouse/fixtures/SuppressionFixtures.java
@@ -12,6 +12,7 @@ public class SuppressionFixtures {
     public static Suppression generateSuppression(String reference) {
         return new Suppression(
             TestData.Suppression.createdAt,
+            TestData.Suppression.createdBy,
             reference,
             generateApplicantDetails(),
             generateAddress(),
@@ -27,7 +28,6 @@ public class SuppressionFixtures {
         return new ApplicantDetails(
             TestData.Suppression.ApplicantDetails.fullName,
             TestData.Suppression.ApplicantDetails.previousName,
-            TestData.Suppression.ApplicantDetails.emailAddress,
             TestData.Suppression.ApplicantDetails.dateOfBirth
         );
     }

--- a/src/test/java/uk/gov/companieshouse/mapper/ApplicantDetailsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/ApplicantDetailsMapperTest.java
@@ -9,7 +9,6 @@ import uk.gov.companieshouse.model.ApplicantDetails;
 
 import static uk.gov.companieshouse.TestData.Suppression.ApplicantDetails.fullName;
 import static uk.gov.companieshouse.TestData.Suppression.ApplicantDetails.previousName;
-import static uk.gov.companieshouse.TestData.Suppression.ApplicantDetails.emailAddress;
 import static uk.gov.companieshouse.TestData.Suppression.ApplicantDetails.dateOfBirth;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -28,12 +27,11 @@ public class ApplicantDetailsMapperTest {
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             ApplicantDetailsEntity mapped = mapper.map(
-                new ApplicantDetails(fullName, previousName, emailAddress, dateOfBirth)
+                new ApplicantDetails(fullName, previousName, dateOfBirth)
             );
 
             assertEquals(fullName, mapped.getFullName());
             assertEquals(previousName, mapped.getPreviousName());
-            assertEquals(emailAddress, mapped.getEmailAddress());
             assertEquals(dateOfBirth, mapped.getDateOfBirth());
         }
     }
@@ -48,12 +46,11 @@ public class ApplicantDetailsMapperTest {
         @Test
         void shouldMapValueWhenValueIsNotNull() {
             ApplicantDetails mapped = mapper.map(
-                new ApplicantDetailsEntity(fullName, previousName, emailAddress, dateOfBirth)
+                new ApplicantDetailsEntity(fullName, previousName, dateOfBirth)
             );
 
             assertEquals(fullName, mapped.getFullName());
             assertEquals(previousName, mapped.getPreviousName());
-            assertEquals(emailAddress, mapped.getEmailAddress());
             assertEquals(dateOfBirth, mapped.getDateOfBirth());
         }
     }

--- a/src/test/java/uk/gov/companieshouse/mapper/SuppressionMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/SuppressionMapperTest.java
@@ -61,7 +61,7 @@ public class SuppressionMapperTest {
         @Test
         void shouldMapValueWhenValueIsNotNull() {
 
-            SuppressionEntity mapped = mapper.map(new Suppression(null, "", applicationReference,
+            SuppressionEntity mapped = mapper.map(new Suppression(null, createdBy, applicationReference,
                 new ApplicantDetails(fullName, previousName, dateOfBirth),
                 new Address(line1, line2, town, county, postcode, country),
                 new Address(line1, line2, town, county, postcode, country),
@@ -72,6 +72,7 @@ public class SuppressionMapperTest {
             ));
 
             assertNull(mapped.getCreatedAt());
+            assertEquals(createdBy, mapped.getCreatedBy());
             assertEquals(applicationReference, mapped.getId());
 
             assertEquals(fullName, mapped.getApplicantDetails().getFullName());
@@ -125,6 +126,7 @@ public class SuppressionMapperTest {
             ));
             assertEquals(applicationReference, mapped.getApplicationReference());
             assertEquals(createdAt, mapped.getCreatedAt());
+            assertEquals(createdBy, mapped.getCreatedBy());
 
             assertEquals(fullName, mapped.getApplicantDetails().getFullName());
             assertEquals(previousName, mapped.getApplicantDetails().getPreviousName());

--- a/src/test/java/uk/gov/companieshouse/mapper/SuppressionMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/SuppressionMapperTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import static uk.gov.companieshouse.TestData.Suppression.ApplicantDetails.fullName;
 import static uk.gov.companieshouse.TestData.Suppression.ApplicantDetails.previousName;
-import static uk.gov.companieshouse.TestData.Suppression.ApplicantDetails.emailAddress;
 import static uk.gov.companieshouse.TestData.Suppression.ApplicantDetails.dateOfBirth;
 
 import static uk.gov.companieshouse.TestData.Suppression.Address.line1;
@@ -36,6 +35,7 @@ import static uk.gov.companieshouse.TestData.Suppression.DocumentDetails.descrip
 import static uk.gov.companieshouse.TestData.Suppression.DocumentDetails.date;
 import static uk.gov.companieshouse.TestData.Suppression.applicationReference;
 import static uk.gov.companieshouse.TestData.Suppression.createdAt;
+import static uk.gov.companieshouse.TestData.Suppression.createdBy;
 import static uk.gov.companieshouse.TestData.Suppression.etag;
 
 import static uk.gov.companieshouse.TestData.Suppression.PaymentDetails.reference;
@@ -61,8 +61,8 @@ public class SuppressionMapperTest {
         @Test
         void shouldMapValueWhenValueIsNotNull() {
 
-            SuppressionEntity mapped = mapper.map(new Suppression(null, applicationReference,
-                new ApplicantDetails(fullName, previousName, emailAddress, dateOfBirth),
+            SuppressionEntity mapped = mapper.map(new Suppression(null, "", applicationReference,
+                new ApplicantDetails(fullName, previousName, dateOfBirth),
                 new Address(line1, line2, town, county, postcode, country),
                 new Address(line1, line2, town, county, postcode, country),
                 new DocumentDetails(companyName, companyNumber, description, date),
@@ -76,7 +76,6 @@ public class SuppressionMapperTest {
 
             assertEquals(fullName, mapped.getApplicantDetails().getFullName());
             assertEquals(previousName, mapped.getApplicantDetails().getPreviousName());
-            assertEquals(emailAddress, mapped.getApplicantDetails().getEmailAddress());
             assertEquals(dateOfBirth, mapped.getApplicantDetails().getDateOfBirth());
 
             assertEquals(line1, mapped.getAddressToRemove().getLine1());
@@ -115,8 +114,8 @@ public class SuppressionMapperTest {
 
         @Test
         void shouldMapValueWhenValueIsNotNull() {
-            Suppression mapped = mapper.map(new SuppressionEntity(applicationReference, createdAt,
-                new ApplicantDetailsEntity(fullName, previousName, emailAddress, dateOfBirth),
+            Suppression mapped = mapper.map(new SuppressionEntity(applicationReference, createdAt, createdBy,
+                new ApplicantDetailsEntity(fullName, previousName, dateOfBirth),
                 new AddressEntity(line1, line2, town, county, postcode, country),
                 new AddressEntity(line1, line2, town, county, postcode, country),
                 new DocumentDetailsEntity(companyName, companyNumber, description, date),
@@ -129,7 +128,6 @@ public class SuppressionMapperTest {
 
             assertEquals(fullName, mapped.getApplicantDetails().getFullName());
             assertEquals(previousName, mapped.getApplicantDetails().getPreviousName());
-            assertEquals(emailAddress, mapped.getApplicantDetails().getEmailAddress());
             assertEquals(dateOfBirth, mapped.getApplicantDetails().getDateOfBirth());
 
             assertEquals(line1, mapped.getAddressToRemove().getLine1());

--- a/src/test/java/uk/gov/companieshouse/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/EmailServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.TestData.Suppression.applicationReference;
+import static uk.gov.companieshouse.TestData.Suppression.createdBy;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,6 +61,7 @@ class EmailServiceTest {
         assertEquals(applicationReference, sentEmailData.getSuppression().getApplicationReference());
         assertEquals("1 May 1980", sentEmailData.getApplicantDateOfBirth());
         assertEquals("1 January 2000", sentEmailData.getDocumentDate());
+        assertEquals(createdBy, sentEmailData.getContactEmailAddress());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/service/SuppressionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/SuppressionServiceTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 
 import static uk.gov.companieshouse.TestData.Suppression.applicationReference;
+import static uk.gov.companieshouse.TestData.Suppression.createdBy;
 import static uk.gov.companieshouse.fixtures.SuppressionEntityFixtures.generateSuppressionEntity;
 import static uk.gov.companieshouse.fixtures.SuppressionFixtures.generateAddress;
 import static uk.gov.companieshouse.fixtures.SuppressionFixtures.generateSuppression;
@@ -102,7 +103,10 @@ class SuppressionServiceTest {
         when(suppressionMapper.map(any(Suppression.class))).thenReturn(generateSuppressionEntity(applicationReference));
         when(suppressionRepository.save(any(SuppressionEntity.class))).thenReturn(generateSuppressionEntity(applicationReference));
 
-        assertEquals(applicationReference, suppressionService.saveSuppression(SuppressionFixtures.generateApplicantDetails()));
+        final String actualReference = suppressionService.saveSuppression(
+            SuppressionFixtures.generateApplicantDetails(), createdBy);
+
+        assertEquals(applicationReference, actualReference);
     }
 
     @Test
@@ -111,10 +115,11 @@ class SuppressionServiceTest {
         when(suppressionMapper.map(any(Suppression.class))).thenReturn(generateSuppressionEntity(applicationReference));
         when(suppressionRepository.save(any(SuppressionEntity.class))).thenReturn(generateSuppressionEntity(applicationReference));
 
-        String expectedReference = suppressionService.saveSuppression(SuppressionFixtures.generateApplicantDetails());
+        String actualReference = suppressionService.saveSuppression(
+            SuppressionFixtures.generateApplicantDetails(), createdBy);
 
         verify(suppressionRepository, times(1)).findById(any(String.class));
-        assertEquals(applicationReference, expectedReference);
+        assertEquals(applicationReference, actualReference);
     }
 
     @Test


### PR DESCRIPTION
### JIRA

[Remove "Email" field from "Applicant details" screen](https://companieshouse.atlassian.net/browse/SR-124) 

### Change description

Support removal of Applicant Details > Email Address field from Front-end by: 
- Removing `emailAddress` field from `ApplicantDetails`
- Adding `createdBy` field to root-level `Suppression` object
- Obtaining `createdBy` value from ERIC `ERIC-Authorised-User` header instead of POST data from the frontend.
- Using `createdBy` value as address for sending Confirmation email by first copying value to `ApplicationReceivedEmailData` object under attribute name `contactEmailAddress`

### Related PRs

- companieshouse/suppression-web#132
- companieshouse/chs-notification-api#234

### Swagger Screenshot

<img src="https://user-images.githubusercontent.com/43062389/98004689-21b41400-1de8-11eb-85de-e14dc6406eb1.png" width="400">

### Work Checklist

- [x] Tests added where applicable
- [x] Test coverage of new code meets target of 80%