### PR TITLE
chore(deps): bump tomcat-embed and jackson-databind for security reason

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
         <version.sonar-maven-plugin>3.7.0.1746</version.sonar-maven-plugin>
         <version.avro>1.10.0</version.avro>
         <version.kafka-clients>2.6.0</version.kafka-clients>
+        <version.tomcat-embed-websocket>9.0.40</version.tomcat-embed-websocket>
+        <version.tomcat-embed-core>9.0.40</version.tomcat-embed-core>
     </properties>
 
     <repositories>
@@ -64,6 +66,14 @@
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-websocket</artifactId>
                 </exclusion>
             </exclusions>
 		</dependency>
@@ -107,6 +117,10 @@
             <version>${version.api-helper-java}</version>
             <exclusions>
                 <!-- exclude conflicting jackson core library -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
@@ -172,6 +186,16 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${version.kafka-clients}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${version.tomcat-embed-core}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-websocket</artifactId>
+            <version>${version.tomcat-embed-websocket}</version>
         </dependency>
 
         <!-- Testing -->


### PR DESCRIPTION
### JIRA

N/A

### Change description

Bump  tomcat-embed (CVE-2020-17527) and jackson-databind (CVE-2020-25649) due to security issue reported.

### Swagger Screenshot



### Work Checklist

- [ ] Tests added where applicable
- [ ] Test coverage of new code meets target of 80%

---

### Merge Instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
